### PR TITLE
Fix infinite loop when converting Infinity

### DIFF
--- a/src/unit.coffee
+++ b/src/unit.coffee
@@ -15,6 +15,8 @@ module.exports = class Unit
     @convert(value)[1]
 
   convert: (value) ->
+    if value is Infinity
+      return [value, @si[0] + @unit]
     sign = value / value = abs value
     exp = max @limit, floor log(value) / @baseln
     while exp not of @si and exp > @limit

--- a/test/unit/unit.coffee
+++ b/test/unit/unit.coffee
@@ -65,6 +65,9 @@ describe 'unit class', ->
       unit.convert(1e-6).should.eql [ 1, 'mc_' ]
       unit.convert(1e-9).should.eql [ 1, 'n_' ]
 
+    it 'should work with Infinity', ->
+      unit.convert(Infinity).should.eql [ Infinity, '_']
+
   describe 'when using binary scale', ->
 
     unit = null
@@ -106,3 +109,6 @@ describe 'unit class', ->
     it 'should work with zero exponent', ->
       unit.convert(1).should.eql [ 1, '_' ]
       unit.convert(1023).should.eql [ 1023, '_' ]
+
+    it 'should work with Infinity', ->
+      unit.convert(Infinity).should.eql [ Infinity, '_']


### PR DESCRIPTION
If you convert Infinity, the conversion gets into an infinite loop. I made a quick fix, but feel free to come up with a more elegant solution.